### PR TITLE
Add @Fetch as a valid hibernate query annotation

### DIFF
--- a/misk-hibernate/api/misk-hibernate.api
+++ b/misk-hibernate/api/misk-hibernate.api
@@ -40,6 +40,11 @@ public abstract interface class misk/hibernate/DbTimestampedEntity {
 public abstract interface class misk/hibernate/DbUnsharded : misk/hibernate/DbEntity {
 }
 
+public abstract interface annotation class misk/hibernate/Fetch : java/lang/annotation/Annotation {
+	public abstract fun joinType ()Ljavax/persistence/criteria/JoinType;
+	public abstract fun path ()Ljava/lang/String;
+}
+
 public class misk/hibernate/Gid : java/io/Serializable {
 	public fun <init> ()V
 	public fun <init> (Lmisk/hibernate/Id;Lmisk/hibernate/Id;)V
@@ -180,6 +185,7 @@ public abstract interface class misk/hibernate/Query {
 	public abstract fun delete (Lmisk/hibernate/Session;)I
 	public abstract fun disableCheck (Lmisk/jdbc/Check;)V
 	public abstract fun dynamicAddConstraint (Ljava/lang/String;Lmisk/hibernate/Operator;Ljava/lang/Object;)V
+	public abstract fun dynamicAddFetch (Ljava/lang/String;Ljavax/persistence/criteria/JoinType;)V
 	public abstract fun dynamicAddOrder (Ljava/lang/String;Z)V
 	public abstract fun dynamicList (Lmisk/hibernate/Session;Ljava/util/List;)Ljava/util/List;
 	public abstract fun dynamicList (Lmisk/hibernate/Session;Lkotlin/jvm/functions/Function2;)Ljava/util/List;

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
@@ -1,6 +1,8 @@
 package misk.hibernate
 
 import javax.persistence.criteria.CriteriaBuilder
+import javax.persistence.criteria.JoinType
+import javax.persistence.criteria.JoinType.LEFT
 import javax.persistence.criteria.Predicate
 import javax.persistence.criteria.Root
 import javax.persistence.criteria.Selection
@@ -21,6 +23,9 @@ interface Query<T> {
   fun dynamicAddConstraint(path: String, operator: Operator, value: Any? = null)
 
   fun dynamicAddOrder(path: String, asc: Boolean)
+
+  /** Fetch the given path as a join, using the given joinType */
+  fun dynamicAddFetch(path: String, joinType: JoinType)
 
   fun disableCheck(check: Check)
 
@@ -189,4 +194,14 @@ annotation class Select(
 annotation class Order(
   val path: String,
   val asc: Boolean = true
+)
+
+/**
+ * Annotates a function on a subinterface of [Query] to specify that the association at
+ * the given `path` should be fetched in a single query. The type of join used will be
+ * specified by `joinType`.
+ */
+annotation class Fetch(
+  val path: String = "",
+  val joinType: JoinType = LEFT
 )

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/DbCharacter.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/DbCharacter.kt
@@ -100,6 +100,9 @@ interface CharacterQuery : Query<DbCharacter> {
 
   @Order(path = "name", asc = false)
   fun nameDesc(): CharacterQuery
+
+  @Fetch(path = "actor")
+  fun withActor(): CharacterQuery
 }
 
 data class NameAndReleaseDate(

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
@@ -911,9 +911,6 @@ class ReflectionQueryFactoryTest {
 
     assertThat(exception).isNotNull
     assertThat(exception.message).isNotNull
-
-    val errorMessageRegex = "^could not initialize proxy .* - no Session".toRegex()
-    assertThat(exception.message!!.contains(errorMessageRegex))
   }
 
   @Test

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
@@ -7,6 +7,8 @@ import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.time.FakeClock
 import org.assertj.core.api.Assertions.assertThat
+import org.hibernate.LazyInitializationException
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import wisp.logging.LogCollector
 import java.time.Duration.ofSeconds
@@ -19,9 +21,9 @@ class ReflectionQueryFactoryTest {
   @MiskTestModule
   val module = MoviesTestModule()
 
-  val maxMaxRows = 40
-  val rowCountErrorLimit = 30
-  val rowCountWarningLimit = 20
+  private val maxMaxRows = 40
+  private val rowCountErrorLimit = 30
+  private val rowCountWarningLimit = 20
   private val queryFactory = ReflectionQuery.Factory(
     ReflectionQuery.QueryLimitsConfig(
       maxMaxRows, rowCountErrorLimit, rowCountWarningLimit
@@ -864,6 +866,54 @@ class ReflectionQueryFactoryTest {
       )
         .containsExactly(jurassicPark, rocky, starWars)
     }
+  }
+
+  @Test
+  fun fetchActorEagerly() {
+    val actorName = "Jeff Goldblum"
+    val characterName = "Ian Malcolm"
+
+    transacter.transaction { session ->
+      val jp = session.save(DbMovie("Jurassic Park", LocalDate.of(1993, 6, 9)))
+      val jg = session.save(DbActor(actorName, LocalDate.of(1952, 10, 22)))
+      session.save(DbCharacter(characterName, session.load(jp), session.load(jg)))
+    }
+
+    val character = transacter.transaction { session ->
+      queryFactory.newQuery<CharacterQuery>()
+        .name(characterName)
+        .withActor()
+        .uniqueResult(session)
+    }
+
+    assertThat(character?.actor?.name).isEqualTo(actorName)
+  }
+
+  @Test
+  fun fetchActorWithoutSpecifyingEager() {
+    val characterName = "Ian Malcolm"
+
+    transacter.transaction { session ->
+      val jp = session.save(DbMovie("Jurassic Park", LocalDate.of(1993, 6, 9)))
+      val jg = session.save(DbActor("Jeff Goldblum", LocalDate.of(1952, 10, 22)))
+      session.save(DbCharacter(characterName, session.load(jp), session.load(jg)))
+    }
+
+    val character = transacter.transaction { session ->
+      queryFactory.newQuery<CharacterQuery>()
+        .name(characterName)
+        .uniqueResult(session)
+    }
+
+    val exception = assertThrows(LazyInitializationException::class.java) {
+      character?.actor?.name
+    }
+
+    assertThat(exception).isNotNull
+    assertThat(exception.message).isNotNull
+
+    val errorMessageRegex = "^could not initialize proxy .* - no Session".toRegex()
+    assertThat(exception.message!!.contains(errorMessageRegex))
   }
 
   @Test

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryValidationTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryValidationTest.kt
@@ -64,7 +64,7 @@ class ReflectionQueryFactoryValidationTest {
     ).hasMessage(
       """
         |Query class ${AnnotationRequiredOnQuery::class.java.name} has problems:
-        |  name() must be annotated @Constraint, @Order or @Select""".trimMargin()
+        |  name() must be annotated @Constraint, @Fetch, @Order, or @Select""".trimMargin()
     )
   }
 


### PR DESCRIPTION
Allow users to specify the `@Fetch` annotation on association columns
during the query to fetch those associations eagerly at runtime.

Example:
**Object and Interface**
```
@Entity
@Table(name = "characters")
class DbCharacter() { 
  @Column(nullable = false)
  lateinit var name: String
  
  ...
  
  @ManyToOne(fetch = FetchType.LAZY)
  @JoinColumn(name = "actor_id", updatable = false, insertable = false)
  var actor: DbActor? = null
}

interface CharacterQuery : Query<DbCharacter> {
  @Constraint("name")
  fun name(name: String): CharacterQuery
  
  ...

  @Fetch(path = "actor")
  fun withActor(): CharacterQuery
}
```
**Original**: Two DB Queries:
```
val actorName = transacter.transaction { session ->
  queryFactory.newQuery<CharacterQuery>()
    .name(characterName)
    .uniqueResult(session)
    ?.actor
    ?.name
}
```
```
Hibernate: /* select generatedAlias0 from DbCharacter as generatedAlias0 where generatedAlias0.name=:param0 */ select dbcharacte0_.id as id1_1_, dbcharacte0_.movie_id as movie_id2_1_, dbcharacte0_.actor_id as actor_id3_1_, dbcharacte0_.created_at as created_4_1_, dbcharacte0_.name as name5_1_, dbcharacte0_.updated_at as updated_6_1_ from characters dbcharacte0_ where dbcharacte0_.name=? limit ?
Hibernate: select dbactor0_.id as id1_0_0_, dbactor0_.birth_date as birth_da2_0_0_, dbactor0_.created_at as created_3_0_0_, dbactor0_.name as name4_0_0_, dbactor0_.updated_at as updated_5_0_0_ from actors dbactor0_ where dbactor0_.id=?
```
**New**: Single DB Query:
```
val actorName = transacter.transaction { session ->
  queryFactory.newQuery<CharacterQuery>()
    .name(characterName)
    .withActor()
    .uniqueResult(session)
    ?.actor
    ?.name
}
```
```
Hibernate: /* select generatedAlias0 from DbCharacter as generatedAlias0 left join fetch generatedAlias0.actor as generatedAlias1 where generatedAlias0.name=:param0 */ select dbcharacte0_.id as id1_1_0_, dbcharacte0_.movie_id as movie_id2_1_0_, dbactor1_.id as id1_0_1_, dbcharacte0_.actor_id as actor_id3_1_0_, dbcharacte0_.created_at as created_4_1_0_, dbcharacte0_.name as name5_1_0_, dbcharacte0_.updated_at as updated_6_1_0_, dbactor1_.birth_date as birth_da2_0_1_, dbactor1_.created_at as created_3_0_1_, dbactor1_.name as name4_0_1_, dbactor1_.updated_at as updated_5_0_1_ from characters dbcharacte0_ left outer join actors dbactor1_ on dbcharacte0_.actor_id=dbactor1_.id where dbcharacte0_.name=? limit ?
```

